### PR TITLE
Add support for env var configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@ Provides Patroni related metrics for Prometheus.
 
 This exporter scrapes Patroni API (https://github.com/zalando/patroni) and transforms the obtained information into Prometheus-scrapable (https://prometheus.io/) format.
 
-The following commandline arguments are available:
-- port: `-p`, `--port` specifies the port it should listen at
-- bind: `-b`, `--bind` specifies the address to bind to
-- patroni url: `-u`, `--patroni-url` specifies the full to path the patroni API endpoint
-- debug: `-d`, `--debug` enables debug output
-- timeout: `-t`, `--timeout` configures the timeout for patroni API
-- address family: `-a`, `--address-family` chooses which adress family to use. Either `ipv4` (`AF_INET`) or `ipv6` (`AF_INET6`). If listening on both `ipv6` and `ipv4` is required, `AF_INET6` and a bind to '' or '::' must be used (the unfortunate side-effect is that it listens on all interfaces)
-- requests verify: `--requests-verify` Accepts `true|false`, in which case it controls whether Python's requests library verifies the server's TLS certificate. It also accepts a path to a CA bundle to use. Defaults to ``true``
+Configuration can by environment variables or commandline arguments. If both is available the value of the commandline argument is taken.
+The following configuration parameters are available:
+- port: `PATRONI_EXPORTER_PORT`, `-p`, `--port` specifies the port it should listen at
+- bind: `PATRONI_EXPORTER_BIND`, `-b`, `--bind` specifies the address to bind to
+- patroni url: `PATRONI_EXPORTER_URL`, `-u`, `--patroni-url` specifies the full to path the patroni API endpoint
+- debug: `PATRONI_EXPORTER_DEBUG`, `-d`, `--debug` enables debug output
+- timeout: `PATRONI_EXPORTER_TIMEOUT`, `-t`, `--timeout` configures the timeout for patroni API
+- address family: `PATRONI_EXPORTER_ADDRESS_FAMILY`, `-a`, `--address-family` chooses which adress family to use. Either `ipv4` (`AF_INET`) or `ipv6` (`AF_INET6`). If listening on both `ipv6` and `ipv4` is required, `AF_INET6` and a bind to '' or '::' must be used (the unfortunate side-effect is that it listens on all interfaces)
+- requests verify: `PATRONI_EXPORTER_REQUEST_VERIFY`, `--requests-verify` Accepts `true|false`, in which case it controls whether Python's requests library verifies the server's TLS certificate. It also accepts a path to a CA bundle to use. Defaults to ``true``
 
 This service also responds on the `/health` endpoint and can be monitored this way.
 

--- a/patroni_exporter.py
+++ b/patroni_exporter.py
@@ -25,6 +25,7 @@ import logging
 import argparse
 import socket
 import requests
+from os import environ
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger('patroni-exporter')
@@ -229,35 +230,35 @@ class PatroniExporter:
         parser.add_argument('-p', '--port',
                             dest='port',
                             type=int,
-                            default=9547,
+                            default=environ.get('PATRONI_EXPORTER_PORT', 9547),
                             help='Port to bind to')
         parser.add_argument('-b', '--bind',
                             dest='bind',
-                            default='',
+                            default=environ.get('PATRONI_EXPORTER_BIND', ''),
                             help='Interface to listen at')
         parser.add_argument('-u', '--patroni-url',
                             dest='url',
-                            default='http://localhost:8008/patroni',
+                            default=environ.get('PATRONI_EXPORTER_URL', 'http://localhost:8008/patroni'),
                             help='Patroni API url '
                                  'where to send GET requests to')
         parser.add_argument('-d', '--debug',
                             dest='debug',
                             action='store_true',
-                            default=False,
+                            default=environ.get('PATRONI_EXPORTER_DEBUG', False),
                             help='Enable debug output')
         parser.add_argument('-t', '--timeout',
-                            default=5,
+                            default=environ.get('PATRONI_EXPORTER_TIMEOUT', 5),
                             type=int,
                             dest='timeout',
                             help='Patroni API GET timeout')
         parser.add_argument('-a', '--address-family',
                             dest='address_family',
-                            default='AF_INET',
+                            default=environ.get('PATRONI_EXPORTER_ADDRESS_FAMILY', 'AF_INET'),
                             help='Socket address family. For example '
                                  '"AF_INET" for ipv4 or "AF_INET6" for ipv6')
         parser.add_argument('--requests-verify',
                             dest='requests_verify',
-                            default='true',
+                            default=environ.get('PATRONI_EXPORTER_REQUEST_VERIFY', 'true'),
                             help="""Accepts `true|false`, 
                                     in which case it controls
                                     whether requests verify the server's 


### PR DESCRIPTION
Support for configuration through environment variables is the way to go for application deployed on kubernetes. This PR adds a way to configure patroni-exporter with env vars. Default stay as before. If commandline arguments are passed as well as env vars, the command line arguments are taken.