### PR TITLE
Gracefully handle exporting from replicas.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ docker build -t patroni_exporter .
 ```
 docker run -d -ti patroni_exporter --port some_port --patroni-url http://some_host_fqdn:some_port/patroni --timeout 5 --debug
 ```
+
+## Known issues/limitations/workarounds
+
+- due to how Patroni replicas respond with their information, but, when compared to primary, use HTTP code 503 (Service Unavailable) to avoid being registered as write-capable endpoints on load balancers, the exporter will attempt proper parsing when the response is a JSON with key-value `{"role": "replica"}`

--- a/patroni_exporter.py
+++ b/patroni_exporter.py
@@ -55,8 +55,9 @@ class PatroniCollector:
         try:
             r = requests.get(self.url, timeout=self.timeout,
                              verify=self.requests_verify)
-            r.raise_for_status()
             self.scrape = r.json()
+            if not self.scrape.get('role') == 'replica':
+                r.raise_for_status()
             self.status = '200 OK'
         except Exception as e:
             self.status = '503 Service Unavailable'


### PR DESCRIPTION
Due to how Patroni operates, all replica nodes report the same data about themselves as the primary does, but return a 5xx code to not end up being registered as a working service in load balancer backends when they shouldn't be receiving write operations. This patch is meant to remediate that behavior.