### PR TITLE
Pip packaging and WSGI logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ docker build -t patroni_exporter .
 docker run -d -ti patroni_exporter --port some_port --patroni-url http://some_host_fqdn:some_port/patroni --timeout 5 --debug
 ```
 
+## Pip package
+
+To create pip-package you need execute this command:
+
+```
+python setup.py sdist
+```
+
+If the command is successful, then the directory `dist` well be contain the `.tar.gz` pip-package.
+
 ## Known issues/limitations/workarounds
 
 - due to how Patroni replicas respond with their information, but, when compared to primary, use HTTP code 503 (Service Unavailable) to avoid being registered as write-capable endpoints on load balancers, the exporter will attempt proper parsing when the response is a JSON with key-value `{"role": "replica"}`

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,9 @@
+"""
+patroni_exporter
+
+Export Patroni metrics in Prometheus format.
+"""
+
+__version__ = "0.0.2"
+__author__ = 'Jan Tomsa'
+__credits__ = 'ops@showmax.com'

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,11 @@ from setuptools import setup
 
 setup(
     name='patroni_exporter',
-    version='0.0.1',
+    version='0.0.2',
     description='Export Patroni metrics in Prometheus format',
+    url='https://github.com/Showmax/patroni-exporter',
     author='Jan Tomsa',
     author_email='ops@showmax.com',
     scripts=['patroni_exporter.py'],
+    install_requires=['prometheus_client','python-dateutil','requests'],
 )


### PR DESCRIPTION
Hello!
I found that logs like this
```
 [06/Jul/2021 13:01:09] "GET /metrics HTTP/1.1" 200 3123
```
are written at any logging level.

I have overridden the default behavior with a handler. Now such logs are written only in the DEBUG level.

I also added some files so that I could pack the script into a pip-package.