### PR TITLE
Refresh stale health status on health check request

### DIFF
--- a/patroni_exporter.py
+++ b/patroni_exporter.py
@@ -285,6 +285,7 @@ class PatroniExporter:
 
         url = urlparse(request_uri(environ))
         if url.path == '/health':
+            self.collector.scrape_patroni()  # refresh collector status
             start_response(self.collector.status, [('Content-Type',
                                                     'application/json')])
             return [b'{}']


### PR DESCRIPTION
This PR addresses the following failure scenario:
1. No Prometheus is periodically scraping this exporter, Patroni daemon is down
2. Exporter starts, during initialization attempts to connect to Patroni daemon, fails and caches the exception as 503 in `self.collector.status`.
3. Without the fix, any request to the `/health` endpoint will result in a 503 response, even if the Patroni daemon starts running properly, but only until the first metric scrape once Patroni is running.